### PR TITLE
解决程序集卸载问题

### DIFF
--- a/src/MCPP.Net/Core/CecilAssemblyBuilder.cs
+++ b/src/MCPP.Net/Core/CecilAssemblyBuilder.cs
@@ -1,0 +1,697 @@
+﻿using MCPP.Net.Models;
+using ModelContextProtocol.Server;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.ComponentModel;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace MCPP.Net.Core
+{
+    /// <summary>
+    /// 使用 Mono.Cecil 动态生成程序集
+    /// </summary>
+    public class CecilAssemblyBuilder : IAssemblyBuilder
+    {
+        private readonly ILogger _logger;
+        private readonly IWebHostEnvironment _hostEnvironment;
+        private readonly string _storageDirectory;
+        private readonly string _assemblyDirectory;
+
+        public CecilAssemblyBuilder(
+            ILogger<CecilAssemblyBuilder> logger,
+            IWebHostEnvironment hostEnvironment)
+        {
+            _logger = logger;
+            _hostEnvironment = hostEnvironment;
+            _storageDirectory = Path.Combine(_hostEnvironment.ContentRootPath, "ImportedSwaggers");
+            _assemblyDirectory = _storageDirectory; // 使用相同目录存储程序集
+        }
+
+        public string Build(JObject swaggerDoc, SwaggerImportRequest request, string baseUrl)
+        {
+            string assemblyName = $"{request.NameSpace}.{request.ClassName}";
+            string fileName = $"{assemblyName}.dll";
+            string assemblyPath = Path.Combine(_assemblyDirectory, fileName);
+
+            // 创建新的程序集定义
+            var assemblyDefinition = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition(assemblyName, new Version(1, 0, 0, 0)),
+                assemblyName,
+                ModuleKind.Dll);
+
+            // 创建主模块
+            ModuleDefinition moduleDefinition = assemblyDefinition.MainModule;
+
+            // 添加必要的引用
+            moduleDefinition.ImportReference(typeof(object));
+            moduleDefinition.ImportReference(typeof(StringBuilder));
+            moduleDefinition.ImportReference(typeof(McpServerToolTypeAttribute));
+            moduleDefinition.ImportReference(typeof(McpServerToolAttribute));
+            moduleDefinition.ImportReference(typeof(DescriptionAttribute));
+
+            // 创建类型定义
+            TypeDefinition typeDefinition = new TypeDefinition(
+                request.NameSpace,
+                request.ClassName,
+                Mono.Cecil.TypeAttributes.Public | Mono.Cecil.TypeAttributes.Abstract | Mono.Cecil.TypeAttributes.Sealed | Mono.Cecil.TypeAttributes.Class,
+                moduleDefinition.ImportReference(typeof(object)));
+
+            // 添加默认构造函数
+            var defaultCtor = new MethodDefinition(
+                ".ctor",
+                Mono.Cecil.MethodAttributes.Public | Mono.Cecil.MethodAttributes.HideBySig | Mono.Cecil.MethodAttributes.SpecialName | Mono.Cecil.MethodAttributes.RTSpecialName,
+                moduleDefinition.ImportReference(typeof(void)));
+
+            var il = defaultCtor.Body.GetILProcessor();
+            il.Append(il.Create(OpCodes.Ldarg_0));
+            il.Append(il.Create(OpCodes.Call, moduleDefinition.ImportReference(typeof(object).GetConstructor(Type.EmptyTypes))));
+            il.Append(il.Create(OpCodes.Ret));
+
+            typeDefinition.Methods.Add(defaultCtor);
+
+            // 添加McpServerToolType特性
+            var customAttribute = new CustomAttribute(
+                moduleDefinition.ImportReference(typeof(McpServerToolTypeAttribute).GetConstructor(Type.EmptyTypes)));
+            typeDefinition.CustomAttributes.Add(customAttribute);
+
+            // 解析Swagger Paths并创建方法
+            JObject paths = (JObject)swaggerDoc["paths"]!;
+
+            foreach (var pathPair in paths)
+            {
+                string path = pathPair.Key;
+                JObject operations = (JObject)pathPair.Value!;
+
+                foreach (var operationPair in operations)
+                {
+                    string httpMethod = operationPair.Key.ToUpper();
+                    JObject operation = (JObject)operationPair.Value!;
+
+                    // 使用namespace + class + path生成operationId
+                    string operationId = $"{request.NameSpace}_{request.ClassName}_{httpMethod}_{path.Replace("/", "_").Trim('_')}";
+                    string summary = operation["summary"]?.ToString() ?? $"HTTP {httpMethod} {path}";
+                    string description = operation["description"]?.ToString() ?? summary;
+
+                    // 创建方法
+                    CreateDynamicMethod(moduleDefinition, typeDefinition, operationId, path, httpMethod, summary, description, operation, baseUrl);
+                }
+            }
+
+            // 将类型添加到模块
+            moduleDefinition.Types.Add(typeDefinition);
+
+            // 将程序集写入磁盘
+            assemblyDefinition.Write(assemblyPath);
+
+            return assemblyPath;
+        }
+        
+        /// <summary>
+         /// 创建动态方法
+         /// </summary>
+         /// <param name="moduleDefinition">模块定义</param>
+         /// <param name="typeDefinition">类型定义</param>
+         /// <param name="operationId">操作ID</param>
+         /// <param name="path">API路径</param>
+         /// <param name="httpMethod">HTTP方法</param>
+         /// <param name="summary">摘要</param>
+         /// <param name="description">描述</param>
+         /// <param name="operation">操作定义</param>
+         /// <param name="baseUrl">API基础URL</param>
+        private void CreateDynamicMethod(
+            ModuleDefinition moduleDefinition,
+            TypeDefinition typeDefinition,
+            string operationId,
+            string path,
+            string httpMethod,
+            string summary,
+            string description,
+            JObject operation,
+            string baseUrl)
+        {
+            // 规范化方法名
+            string methodName = NormalizeMethodName(operationId);
+
+            // 获取参数列表
+            JArray? parameters = (JArray?)operation["parameters"];
+            JObject? requestBody = (JObject?)operation["requestBody"];
+
+            List<string> parameterNames = new List<string>();
+            List<string> parameterDescriptions = new List<string>();
+            List<string> pathParams = new List<string>();
+            List<string> queryParams = new List<string>();
+
+            // 创建方法定义
+            var methodDefinition = new MethodDefinition(
+                methodName,
+                Mono.Cecil.MethodAttributes.Public | Mono.Cecil.MethodAttributes.Static,
+                moduleDefinition.ImportReference(typeof(string)));
+
+            // 处理Path和Query参数
+            if (parameters != null)
+            {
+                foreach (JObject param in parameters)
+                {
+                    string paramName = param["name"]?.ToString() ?? "";
+                    string paramIn = param["in"]?.ToString() ?? "";
+
+                    if (paramIn == "path" || paramIn == "query")
+                    {
+                        string normalizedName = NormalizeParameterName(paramName);
+                        var parameterDefinition = new ParameterDefinition(
+                            normalizedName,
+                            Mono.Cecil.ParameterAttributes.None,
+                            moduleDefinition.ImportReference(typeof(string)));
+
+                        methodDefinition.Parameters.Add(parameterDefinition);
+
+                        // 为参数添加Description特性
+                        string paramDescription = param["description"]?.ToString() ?? $"参数 {paramName}";
+                        var descriptionAttr = new CustomAttribute(
+                            moduleDefinition.ImportReference(
+                                typeof(DescriptionAttribute).GetConstructor(new[] { typeof(string) })));
+                        descriptionAttr.ConstructorArguments.Add(
+                            new CustomAttributeArgument(moduleDefinition.ImportReference(typeof(string)), paramDescription));
+                        parameterDefinition.CustomAttributes.Add(descriptionAttr);
+
+                        parameterNames.Add(normalizedName);
+                        parameterDescriptions.Add(paramDescription);
+
+                        if (paramIn == "path")
+                        {
+                            pathParams.Add(paramName);
+                        }
+                        else if (paramIn == "query")
+                        {
+                            queryParams.Add(paramName);
+                        }
+                    }
+                }
+            }
+
+            // 处理请求体
+            bool hasRequestBody = false;
+            string requestBodySchema = "{}";
+            string requestBodyDescription = "请求体 (JSON格式)";
+
+            if (requestBody != null)
+            {
+                hasRequestBody = true;
+                var parameterDefinition = new ParameterDefinition(
+                    "requestBody",
+                    Mono.Cecil.ParameterAttributes.None,
+                    moduleDefinition.ImportReference(typeof(string)));
+
+                methodDefinition.Parameters.Add(parameterDefinition);
+
+                // 尝试提取请求体Schema和描述
+                if (requestBody["content"] is JObject content &&
+                    content["application/json"] is JObject jsonContent &&
+                    jsonContent["schema"] is JObject schema)
+                {
+                    requestBodySchema = schema.ToString(Formatting.Indented);
+
+                    // 生成详细的请求体描述
+                    var schemaDescription = new StringBuilder();
+                    schemaDescription.AppendLine("请求体结构:");
+                    GenerateSchemaDescription(schema, schemaDescription, 1);
+                    requestBodyDescription = schemaDescription.ToString();
+                }
+
+                // 为请求体参数添加Description特性
+                var descriptionAttr = new CustomAttribute(
+                    moduleDefinition.ImportReference(
+                        typeof(DescriptionAttribute).GetConstructor(new[] { typeof(string) })));
+                descriptionAttr.ConstructorArguments.Add(
+                    new CustomAttributeArgument(moduleDefinition.ImportReference(typeof(string)), requestBodyDescription));
+                parameterDefinition.CustomAttributes.Add(descriptionAttr);
+
+                parameterNames.Add("requestBody");
+                parameterDescriptions.Add(requestBodyDescription);
+            }
+
+            // 添加McpServerTool特性
+            var mcpServerToolAttr = new CustomAttribute(
+                moduleDefinition.ImportReference(
+                    typeof(McpServerToolAttribute).GetConstructor(Type.EmptyTypes)));
+
+            // 设置Name属性
+            var nameProperty = typeof(McpServerToolAttribute).GetProperty("Name");
+            if (nameProperty != null && nameProperty.GetSetMethod() != null)
+            {
+                mcpServerToolAttr.Properties.Add(
+                    new Mono.Cecil.CustomAttributeNamedArgument(
+                        "Name",
+                        new CustomAttributeArgument(moduleDefinition.ImportReference(typeof(string)), methodName.ToLower())));
+            }
+
+            methodDefinition.CustomAttributes.Add(mcpServerToolAttr);
+
+            // 添加Description特性
+            var methodDescAttr = new CustomAttribute(
+                moduleDefinition.ImportReference(
+                    typeof(DescriptionAttribute).GetConstructor(new[] { typeof(string) })));
+            methodDescAttr.ConstructorArguments.Add(
+                new CustomAttributeArgument(moduleDefinition.ImportReference(typeof(string)), description));
+            methodDefinition.CustomAttributes.Add(methodDescAttr);
+
+            // 生成示例HTTP请求代码
+            string fullPath = path;
+            int placeholderIndex = 0;
+            foreach (var pathParam in pathParams)
+            {
+                // 获取规范化的参数名
+                string normalizedName = NormalizeParameterName(pathParam);
+                // 使用简单的字符串替换，添加占位符
+                fullPath = fullPath.Replace($"{{{pathParam}}}", $"{{{placeholderIndex++}}}");
+            }
+
+            string queryString = "";
+            if (queryParams.Count > 0)
+            {
+                queryString = "?";
+                for (int i = 0; i < queryParams.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        queryString += "&";
+                    }
+                    string paramName = queryParams[i];
+                    string normalizedName = NormalizeParameterName(paramName);
+                    queryString += $"{paramName}={{{placeholderIndex++}}}";
+                }
+            }
+
+            string fullUrl = baseUrl + fullPath + queryString;
+
+            // 获取ILProcessor
+            ILProcessor ilProcessor = methodDefinition.Body.GetILProcessor();
+
+            // 创建变量
+            var httpClientVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(HttpClient)));
+            var responseVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(HttpResponseMessage)));
+            var contentVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(string)));
+            var formattedUrlVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(string)));
+
+            methodDefinition.Body.Variables.Add(httpClientVar);
+            methodDefinition.Body.Variables.Add(responseVar);
+            methodDefinition.Body.Variables.Add(contentVar);
+            methodDefinition.Body.Variables.Add(formattedUrlVar);
+
+            // 格式化 URL，替换路径参数和查询参数
+            if (pathParams.Count > 0 || queryParams.Count > 0)
+            {
+                // 使用 string.Format 方法格式化 URL
+                ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, fullUrl));
+
+                // 添加路径参数
+                foreach (var pathParam in pathParams)
+                {
+                    string normalizedName = NormalizeParameterName(pathParam);
+                    int paramIndex = FindParameterIndex(methodDefinition.Parameters, normalizedName);
+                    if (paramIndex >= 0)
+                    {
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg, paramIndex));
+                    }
+                    else
+                    {
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, ""));
+                    }
+                }
+
+                // 添加查询参数
+                foreach (var queryParam in queryParams)
+                {
+                    string normalizedName = NormalizeParameterName(queryParam);
+                    int paramIndex = FindParameterIndex(methodDefinition.Parameters, normalizedName);
+                    if (paramIndex >= 0)
+                    {
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg, paramIndex));
+                    }
+                    else
+                    {
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, ""));
+                    }
+                }
+
+                // 调用 string.Format 方法
+                var stringFormatMethod = moduleDefinition.ImportReference(
+                    typeof(string).GetMethod("Format", new Type[] {
+                        typeof(string),
+                        typeof(object),
+                        typeof(object),
+                        typeof(object)
+                    }));
+
+                if (pathParams.Count + queryParams.Count == 1)
+                {
+                    stringFormatMethod = moduleDefinition.ImportReference(
+                        typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object) }));
+                }
+                else if (pathParams.Count + queryParams.Count == 2)
+                {
+                    stringFormatMethod = moduleDefinition.ImportReference(
+                        typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object), typeof(object) }));
+                }
+                else if (pathParams.Count + queryParams.Count == 3)
+                {
+                    stringFormatMethod = moduleDefinition.ImportReference(
+                        typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object), typeof(object), typeof(object) }));
+                }
+                else if (pathParams.Count + queryParams.Count > 3)
+                {
+                    // 对于更多参数，使用 params 版本的 Format 方法
+                    stringFormatMethod = moduleDefinition.ImportReference(
+                        typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object[]) }));
+
+                    // 创建数组
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldc_I4, pathParams.Count + queryParams.Count));
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Newarr, moduleDefinition.ImportReference(typeof(object))));
+
+                    // 填充数组
+                    int index = 0;
+                    foreach (var pathParam in pathParams)
+                    {
+                        string normalizedName = NormalizeParameterName(pathParam);
+                        int paramIndex = FindParameterIndex(methodDefinition.Parameters, normalizedName);
+
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Dup));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldc_I4, index));
+
+                        if (paramIndex >= 0)
+                        {
+                            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg, paramIndex));
+                        }
+                        else
+                        {
+                            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, ""));
+                        }
+
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Stelem_Ref));
+                        index++;
+                    }
+
+                    foreach (var queryParam in queryParams)
+                    {
+                        string normalizedName = NormalizeParameterName(queryParam);
+                        int paramIndex = FindParameterIndex(methodDefinition.Parameters, normalizedName);
+
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Dup));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldc_I4, index));
+
+                        if (paramIndex >= 0)
+                        {
+                            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg, paramIndex));
+                        }
+                        else
+                        {
+                            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, ""));
+                        }
+
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Stelem_Ref));
+                        index++;
+                    }
+                }
+
+                ilProcessor.Append(ilProcessor.Create(OpCodes.Call, stringFormatMethod));
+                ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, formattedUrlVar));
+            }
+            else
+            {
+                // 如果没有参数，直接使用 fullUrl
+                ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, fullUrl));
+                ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, formattedUrlVar));
+            }
+
+            // ----------------- 新增发送 HTTP 请求的 IL代码 -----------------
+            // 创建 HttpClient 实例
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Newobj, moduleDefinition.ImportReference(typeof(HttpClient).GetConstructor(Type.EmptyTypes))));
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, httpClientVar));
+
+            // 根据HTTP方法处理不同类型的请求
+            switch (httpMethod.ToUpper())
+            {
+                case "GET":
+                    // 发送 GET 请求
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
+                    var getAsyncMethod = moduleDefinition.ImportReference(typeof(HttpClient).GetMethod("GetAsync", new Type[] { typeof(string) }));
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, getAsyncMethod));
+                    break;
+
+                case "DELETE":
+                    // 发送 DELETE 请求
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
+                    var deleteAsyncMethod = moduleDefinition.ImportReference(typeof(HttpClient).GetMethod("DeleteAsync", new Type[] { typeof(string) }));
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, deleteAsyncMethod));
+                    break;
+
+                case "POST":
+                case "PUT":
+                case "PATCH":
+                    // 创建 HttpContent 用于请求内容
+                    var requestContentVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(StringContent)));
+                    methodDefinition.Body.Variables.Add(requestContentVar);
+
+                    if (hasRequestBody)
+                    {
+                        // 创建 StringContent 实例
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg, methodDefinition.Parameters.Count - 1)); // 最后一个参数是requestBody
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Call, moduleDefinition.ImportReference(typeof(Encoding).GetProperty("UTF8").GetGetMethod())));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, "application/json"));
+                        var stringContentCtor = moduleDefinition.ImportReference(
+                            typeof(StringContent).GetConstructor(new Type[] { typeof(string), typeof(Encoding), typeof(string) }));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Newobj, stringContentCtor));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, requestContentVar));
+                    }
+                    else
+                    {
+                        // 创建空的 StringContent
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, "{}"));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Call, moduleDefinition.ImportReference(typeof(Encoding).GetProperty("UTF8").GetGetMethod())));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, "application/json"));
+                        var stringContentCtor = moduleDefinition.ImportReference(
+                            typeof(StringContent).GetConstructor(new Type[] { typeof(string), typeof(Encoding), typeof(string) }));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Newobj, stringContentCtor));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, requestContentVar));
+                    }
+
+                    // 根据不同的HTTP方法选择相应的请求方式
+                    if (httpMethod.ToUpper() == "POST")
+                    {
+                        // 发送 POST 请求
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, requestContentVar));
+                        var postAsyncMethod = moduleDefinition.ImportReference(
+                            typeof(HttpClient).GetMethod("PostAsync", new Type[] { typeof(string), typeof(HttpContent) }));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, postAsyncMethod));
+                    }
+                    else if (httpMethod.ToUpper() == "PUT")
+                    {
+                        // 发送 PUT 请求
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, requestContentVar));
+                        var putAsyncMethod = moduleDefinition.ImportReference(
+                            typeof(HttpClient).GetMethod("PutAsync", new Type[] { typeof(string), typeof(HttpContent) }));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, putAsyncMethod));
+                    }
+                    else // PATCH 和其他方法
+                    {
+                        // 对于 PATCH 方法，使用 SendAsync 方法
+                        // 先创建一个临时变量存储HttpRequestMessage
+                        var requestMessageVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(HttpRequestMessage)));
+                        methodDefinition.Body.Variables.Add(requestMessageVar);
+
+                        // 创建HttpMethod.Patch
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Call, moduleDefinition.ImportReference(
+                            typeof(HttpMethod).GetProperty("Patch").GetGetMethod())));
+
+                        // 加载URL
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
+
+                        // 创建 HttpRequestMessage
+                        var httpRequestMessageCtor = moduleDefinition.ImportReference(
+                            typeof(HttpRequestMessage).GetConstructor(new Type[] { typeof(HttpMethod), typeof(string) }));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Newobj, httpRequestMessageCtor));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, requestMessageVar));
+
+                        // 设置请求内容
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, requestMessageVar));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, requestContentVar));
+
+                        var contentSetter = moduleDefinition.ImportReference(
+                            typeof(HttpRequestMessage).GetProperty("Content").GetSetMethod());
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, contentSetter));
+
+                        // 发送请求
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, requestMessageVar));
+
+                        var sendAsyncMethod = moduleDefinition.ImportReference(
+                            typeof(HttpClient).GetMethod("SendAsync", new Type[] { typeof(HttpRequestMessage) }));
+                        ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, sendAsyncMethod));
+                    }
+                    break;
+
+                default:
+                    // 默认使用GET请求
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
+                    var defaultGetAsyncMethod = moduleDefinition.ImportReference(typeof(HttpClient).GetMethod("GetAsync", new Type[] { typeof(string) }));
+                    ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, defaultGetAsyncMethod));
+                    break;
+            }
+
+            // 调用 Task<HttpResponseMessage>.Result 获取响应结果
+            var taskResponseResultGetter = moduleDefinition.ImportReference(
+                typeof(System.Threading.Tasks.Task<HttpResponseMessage>).GetProperty("Result").GetGetMethod());
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, taskResponseResultGetter));
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, responseVar));
+
+            // 从响应中获取 HttpContent
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, responseVar));
+            var getContentGetter = moduleDefinition.ImportReference(
+                typeof(HttpResponseMessage).GetProperty("Content").GetGetMethod());
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, getContentGetter));
+
+            // 调用 HttpContent.ReadAsStringAsync 并同步获取响应体字符串
+            var readAsStringAsyncMethod = moduleDefinition.ImportReference(
+                typeof(HttpContent).GetMethod("ReadAsStringAsync", Type.EmptyTypes));
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, readAsStringAsyncMethod));
+            var taskStringResultGetter = moduleDefinition.ImportReference(
+                typeof(System.Threading.Tasks.Task<string>).GetProperty("Result").GetGetMethod());
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, taskStringResultGetter));
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, contentVar));
+            // ----------------- 结束发送 HTTP 请求的 IL代码 -----------------
+
+            // 将响应体字符串加载到栈顶，并返回
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, contentVar));
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Ret));
+
+            // 将方法添加到类型
+            typeDefinition.Methods.Add(methodDefinition);
+        }
+
+        /// <summary>
+        /// 生成Schema的描述信息
+        /// </summary>
+        private void GenerateSchemaDescription(JObject schema, StringBuilder description, int indentLevel)
+        {
+            string indent = new string(' ', indentLevel * 2);
+
+            if (schema["type"]?.ToString() == "object")
+            {
+                if (schema["properties"] is JObject properties)
+                {
+                    foreach (var prop in properties)
+                    {
+                        string propName = prop.Key;
+                        JObject propSchema = (JObject)prop.Value!;
+
+                        // 添加属性名和类型
+                        description.Append($"{indent}- {propName}: ");
+
+                        if (propSchema["type"] != null)
+                        {
+                            description.Append(propSchema["type"]!.ToString());
+                        }
+
+                        // 添加描述
+                        if (propSchema["description"] != null)
+                        {
+                            description.Append($" - {propSchema["description"]}");
+                        }
+
+                        description.AppendLine();
+
+                        // 递归处理嵌套对象
+                        if (propSchema["type"]?.ToString() == "object" && propSchema["properties"] != null)
+                        {
+                            GenerateSchemaDescription(propSchema, description, indentLevel + 1);
+                        }
+                        // 处理数组类型
+                        else if (propSchema["type"]?.ToString() == "array" && propSchema["items"] != null)
+                        {
+                            description.Append($"{indent}  - 数组元素类型: ");
+                            if (propSchema["items"]!["type"] != null)
+                            {
+                                description.AppendLine(propSchema["items"]!["type"]!.ToString());
+                            }
+
+                            if (propSchema["items"]!["type"]?.ToString() == "object" &&
+                                propSchema["items"]!["properties"] != null)
+                            {
+                                GenerateSchemaDescription((JObject)propSchema["items"]!, description, indentLevel + 2);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// 规范化方法名
+        /// </summary>
+        /// <param name="operationId">操作ID</param>
+        /// <returns>规范化的方法名</returns>
+        private string NormalizeMethodName(string operationId)
+        {
+            // 移除非法字符，保留字母、数字和下划线
+            string normalized = Regex.Replace(operationId, @"[^a-zA-Z0-9_]", "");
+
+            // 确保以字母开头
+            if (normalized.Length == 0 || !char.IsLetter(normalized[0]))
+            {
+                normalized = "Api" + normalized;
+            }
+
+            return normalized;
+        }
+
+        /// <summary>
+        /// 规范化参数名
+        /// </summary>
+        /// <param name="paramName">参数名</param>
+        /// <returns>规范化的参数名</returns>
+        private string NormalizeParameterName(string paramName)
+        {
+            // 移除非法字符，保留字母、数字和下划线
+            string normalized = Regex.Replace(paramName, @"[^a-zA-Z0-9_]", "");
+
+            // 确保以字母开头
+            if (normalized.Length == 0 || !char.IsLetter(normalized[0]))
+            {
+                normalized = "param" + normalized;
+            }
+
+            // 转换为小驼峰命名
+            return char.ToLowerInvariant(normalized[0]) + normalized.Substring(1);
+        }
+
+        /// <summary>
+        /// 查找参数在集合中的索引
+        /// </summary>
+        /// <param name="parameters">参数集合</param>
+        /// <param name="name">参数名</param>
+        /// <returns>参数索引，找不到返回-1</returns>
+        private int FindParameterIndex(Collection<ParameterDefinition> parameters, string name)
+        {
+            for (int i = 0; i < parameters.Count; i++)
+            {
+                if (parameters[i].Name == name)
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+    }
+}

--- a/src/MCPP.Net/Core/IAssemblyBuilder.cs
+++ b/src/MCPP.Net/Core/IAssemblyBuilder.cs
@@ -1,0 +1,17 @@
+﻿using MCPP.Net.Models;
+using Newtonsoft.Json.Linq;
+
+namespace MCPP.Net.Core
+{
+    /// <summary>
+    /// 程序集生成器标准接口
+    /// </summary>
+    public interface IAssemblyBuilder
+    {
+        /// <summary>
+        /// 根据Swagger文档和请求信息动态生成程序集
+        /// </summary>
+        /// <returns>程序集文件路径</returns>
+        string Build(JObject swaggerDoc, SwaggerImportRequest request, string baseUrl);
+    }
+}

--- a/src/MCPP.Net/Core/IToolAssemblyLoader.cs
+++ b/src/MCPP.Net/Core/IToolAssemblyLoader.cs
@@ -1,0 +1,24 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+namespace MCPP.Net.Core
+{
+    /// <summary>
+    /// 管控程序集的加载和卸载，避免因外部引用导致无法卸载程序集
+    /// </summary>
+    public interface IToolAssemblyLoader
+    {
+        /// <summary>
+        /// 加载程序集
+        /// </summary>
+        /// <remarks>
+        /// 返回值不要包含 <see cref="Assembly"/>, <see cref="Type"/>, <see cref="AssemblyLoadContext"/> 等反射相关类型以及动态程序集中的类型实例，否则在卸载程序集时，可能因外部依赖导致无法卸载程序集
+        /// </remarks>
+        ToolLoadedDetail Load(string assemblyPath);
+
+        /// <summary>
+        /// 卸载程序集
+        /// </summary>
+        void Unload(string assemblyName);
+    }
+}

--- a/src/MCPP.Net/Core/McpServerExtensions.cs
+++ b/src/MCPP.Net/Core/McpServerExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Options;
+using ModelContextProtocol.Server;
+
+namespace MCPP.Net.Core
+{
+    /// <summary>
+    /// <see cref="IMcpServerBuilder"/> extension methods
+    /// </summary>
+    public static class McpServerExtensions
+    {
+        /// <summary>
+        /// 使用 <see cref="McpToolsKeeper"/> 管理 Tools，方便后续的增删操作
+        /// </summary>
+        public static IMcpServerBuilder UseToolsKeeper(this IMcpServerBuilder builder)
+        {
+            builder.Services.AddSingleton<McpToolsKeeper>();
+            builder.Services.AddTransient<IPostConfigureOptions<McpServerOptions>, McpServerOptionsPostConfigure>();
+
+            return builder;
+        }
+    }
+}

--- a/src/MCPP.Net/Core/McpServerOptionsPostConfigure.cs
+++ b/src/MCPP.Net/Core/McpServerOptionsPostConfigure.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Options;
+using ModelContextProtocol.Server;
+
+namespace MCPP.Net.Core
+{
+    /// <summary>
+    /// 覆盖 <see cref="McpServerOptions"/> 默认配置，使用 <see cref="McpToolsKeeper"/> 管理 Tools，方便后续的增删操作
+    /// </summary>
+    public class McpServerOptionsPostConfigure(McpToolsKeeper toolsKeeper) : IPostConfigureOptions<McpServerOptions>
+    {
+        /// <inheritdoc />
+        public void PostConfigure(string? name, McpServerOptions options)
+        {
+            if (options.Capabilities?.Tools?.ToolCollection == null) throw new ArgumentNullException("MCP tools collection is null");
+
+            toolsKeeper.SetTools(options.Capabilities.Tools);
+
+            options.Capabilities.Tools.ToolCollection = [];
+            options.Capabilities.Tools.ListToolsHandler = toolsKeeper.ListToolsHandler;
+            options.Capabilities.Tools.CallToolHandler = toolsKeeper.CallToolHandler;
+        }
+    }
+}

--- a/src/MCPP.Net/Core/McpToolsKeeper.cs
+++ b/src/MCPP.Net/Core/McpToolsKeeper.cs
@@ -1,0 +1,100 @@
+﻿using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Server;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+
+namespace MCPP.Net.Core
+{
+    /// <summary>
+    /// Tool 管理员，可以在运行时添加和删除 Tools
+    /// </summary>
+    public class McpToolsKeeper(ILogger<McpToolsKeeper> logger)
+    {
+        private const string DEFAULT_ID = "__default__";
+
+        private ToolsCapability? _tools;
+        private readonly ConcurrentDictionary<string, ImmutableDictionary<string, McpServerTool>> _map = [];
+
+        /// <summary>
+        /// 使用原始配置初始化<see cref="McpToolsKeeper"/>
+        /// </summary>
+        public void SetTools(ToolsCapability tools)
+        {
+            if (_tools is not null) throw new InvalidOperationException("Tools already been set.");
+            
+            _tools = tools;
+            _map[DEFAULT_ID] = tools.ToolCollection!.ToImmutableDictionary(x => ((IMcpServerPrimitive)x).Name);
+            
+            logger.LogInformation($"McpToolsKeeper 已完成初始化，默认 Tools 共计 {tools.ToolCollection!.Count} 个");
+        }
+
+        /// <summary>
+        /// 添加一个新的 Tool 集合
+        /// </summary>
+        public void Add(string id, IEnumerable<McpServerTool> tools)
+        {
+            if (_map.ContainsKey(id))
+            {
+                Remove(id);
+            }
+
+            _map[id] = tools.ToImmutableDictionary(x => ((IMcpServerPrimitive)x).Name);
+
+            logger.LogInformation($"新增 Tool 集合 [{id}]，共计包含 {tools.Count()} 个 Tools");
+
+            // todo: 需要通过某种机制通知客户端 tools 发生变化了
+            //if (_tools is not null)
+            //{
+            //    _tools.ListChanged = true;
+            //}
+        }
+
+        /// <summary>
+        /// 移除一个 Tool 集合
+        /// </summary>
+        public void Remove(string id)
+        {
+            if (_map.TryRemove(id, out _))
+            {
+                logger.LogInformation($"移出 Tool 集合 [{id}]");
+            }
+            else
+            {
+                logger.LogWarning($"Tool 集合 [{id}] 不存在，无法移除");
+            }
+
+            // todo: 需要通过某种机制通知客户端 tools 发生变化了
+            //if (_tools is not null)
+            //{
+            //    _tools.ListChanged = true;
+            //}
+        }
+
+        /// <summary>
+        /// 获取所有 Tool 集合
+        /// </summary>
+        public Task<ListToolsResult> ListToolsHandler(RequestContext<ListToolsRequestParams> context, CancellationToken token)
+        {
+            var result = new ListToolsResult();
+
+            result.Tools.AddRange(_map.Values.SelectMany(x => x).Select(x => x.Value.ProtocolTool));
+
+            return Task.FromResult(result);
+        }
+
+        /// <summary>
+        /// 调用指定的 Tool
+        /// </summary>
+        public Task<CallToolResponse> CallToolHandler(RequestContext<CallToolRequestParams> context, CancellationToken token)
+        {
+            if (context.Params is not null)
+            {
+                foreach (var tools in _map.Values)
+                {
+                    if (tools.TryGetValue(context.Params.Name, out var tool)) return tool.InvokeAsync(context, token);
+                }
+            }
+            throw new InvalidOperationException($"Unknown tool '{context.Params?.Name}'");
+        }
+    }
+}

--- a/src/MCPP.Net/Core/PluginAssembly.cs
+++ b/src/MCPP.Net/Core/PluginAssembly.cs
@@ -1,0 +1,35 @@
+﻿using MCPP.Net.UnsafeImports;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text.Json;
+
+namespace MCPP.Net.Core
+{
+    /// <summary>
+    /// 程序集元数据信息，方便统一管理释放
+    /// </summary>
+    public class PluginAssembly(Assembly assembly, AssemblyLoadContext context) : IDisposable
+    {
+        /// <summary>
+        /// 绑定到程序集的 <see cref="JsonSerializerOptions"/>
+        /// </summary>
+        /// <remarks>
+        /// Microsoft.Extensions.Ai 内部通过 ConditionalWeakTable 缓存了 Tool 对应的 MethodInfo 信息，如果不释放将无法卸载程序集。
+        /// ConditionalWeakTable 的 Key 为 <see cref="JsonSerializerOptions"/> 对象，所以可以将整个程序集的所有 Tools 对应到一个 <see cref="JsonSerializerOptions"/> 上，在卸载程序集前删除对象引用即可<br/>
+        /// https://github.com/dotnet/extensions/blob/f1f17e642a685df7e87b805be1efe4729ff725e4/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs#L219-L247
+        /// </remarks>
+        public JsonSerializerOptions? SerializerOptions { get; private set; } = UnsafeAIJsonUtilities.CreateDefaultOptions();
+
+        /// <summary>
+        /// 动态生成的程序集
+        /// </summary>
+        public Assembly Assembly => assembly;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            SerializerOptions = null;
+            context.Unload();
+        }
+    }
+}

--- a/src/MCPP.Net/Core/ToolAssemblyLoader.cs
+++ b/src/MCPP.Net/Core/ToolAssemblyLoader.cs
@@ -1,0 +1,116 @@
+﻿using MCPP.Net.Models;
+using MCPP.Net.UnsafeImports;
+using ModelContextProtocol.Server;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace MCPP.Net.Core
+{
+    /// <summary>
+    /// <see cref="IToolAssemblyLoader"/> 的默认实现
+    /// </summary>
+    public class ToolAssemblyLoader(McpToolsKeeper toolsKeeper, ILogger<ToolAssemblyLoader> logger) : IToolAssemblyLoader
+    {
+        private readonly ConcurrentDictionary<string, PluginAssembly> _assemblies = new();
+
+        /// <inheritdoc/>
+        public ToolLoadedDetail Load(string assemblyPath)
+        {
+            // 创建自定义上下文加载程序集，避免重复加载同名程序集
+            var loadContextName = Guid.NewGuid().ToString();
+            var loadContext = new AssemblyLoadContext(loadContextName, true);
+
+            try
+            {
+                var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+
+                var assemblyName = assembly.GetName().Name!;
+
+                var pluginAssembly = new PluginAssembly(assembly, loadContext);
+
+                var importedTools = LoadToolsFromAssembly(pluginAssembly);
+
+                _assemblies[assemblyName] = pluginAssembly;
+
+                return importedTools;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "加载动态程序集失败: {Path}", assemblyPath);
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Unload(string assemblyName)
+        {
+            if (UnloadInternal(assemblyName))
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
+        }
+
+        private bool UnloadInternal(string assemblyName)
+        {
+            if (_assemblies.TryRemove(assemblyName, out var pluginAssembly))
+            {
+                toolsKeeper.Remove(assemblyName);
+                pluginAssembly.Dispose();
+
+                return true;
+            }
+            return false;
+        }
+
+        private ToolLoadedDetail LoadToolsFromAssembly(PluginAssembly pluginAssembly)
+        {
+            var importedTools = new List<ImportedTool>();
+            var tools = new List<McpServerTool>();
+            var registeredMethods = new List<string>();
+
+            foreach (var type in pluginAssembly.Assembly.GetTypes())
+            {
+                // 查找带有McpServerToolType特性的类型
+                var toolTypeAttr = type.GetCustomAttribute<McpServerToolTypeAttribute>();
+                if (toolTypeAttr != null)
+                {
+                    logger.LogInformation("找到工具类型: {TypeName}", type.FullName);
+
+                    // 获取所有带有McpServerTool特性的方法
+                    var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                        .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() != null)
+                        .ToList();
+
+                    // 添加到导入工具列表，方便管理
+                    var importedTool = new ImportedTool
+                    {
+                        NameSpace = type.Namespace ?? "UnknownNamespace",
+                        ClassName = type.Name,
+                        ApiCount = methods.Count,
+                        ImportDate = DateTime.Now,
+                        SwaggerSource = "ImportedSwaggers目录自动加载",
+                        SourceBaseUrl = ""
+                    };
+
+                    if (methods.Count == 0) continue;
+
+                    tools.AddRange(methods.Select(x => UnsafeAIFunctionMcpServerTool.Create(x, pluginAssembly.SerializerOptions!)));
+                    importedTools.Add(importedTool);
+                    registeredMethods.AddRange(methods.Select(x => x.Name));
+
+                    logger.LogInformation("将注册 {Count} 个方法, 来自 {TypeName}", methods.Count, type.FullName);
+                }
+            }
+
+            var assemblyName = pluginAssembly.Assembly.GetName().Name!;
+            toolsKeeper.Add(assemblyName, tools);
+
+            logger.LogInformation("已从 {AssemblyName} 中加载 {ToolCount} 个工具", assemblyName, tools.Count);
+
+            return new(registeredMethods, importedTools);
+        }
+    }
+}

--- a/src/MCPP.Net/Core/ToolLoadedDetail.cs
+++ b/src/MCPP.Net/Core/ToolLoadedDetail.cs
@@ -1,0 +1,9 @@
+﻿using MCPP.Net.Models;
+
+namespace MCPP.Net.Core
+{
+    /// <summary>
+    /// <see cref="IToolAssemblyLoader.Load(string)"/> 的返回值，包含了加载的具体信息
+    /// </summary>
+    public readonly record struct ToolLoadedDetail(List<string> RegisteredMethods, List<ImportedTool> ImportedTools);
+}

--- a/src/MCPP.Net/MCPP.Net.csproj
+++ b/src/MCPP.Net/MCPP.Net.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.4" />
+    <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.7" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />

--- a/src/MCPP.Net/MCPP.Net.xml
+++ b/src/MCPP.Net/MCPP.Net.xml
@@ -30,6 +30,105 @@
             <param name="className">类名</param>
             <returns>操作结果</returns>
         </member>
+        <member name="M:MCPP.Net.Core.CecilAssemblyBuilder.CreateDynamicMethod(Mono.Cecil.ModuleDefinition,Mono.Cecil.TypeDefinition,System.String,System.String,System.String,System.String,System.String,Newtonsoft.Json.Linq.JObject,System.String)">
+            <summary>
+            创建动态方法
+            </summary>
+            <param name="moduleDefinition">模块定义</param>
+            <param name="typeDefinition">类型定义</param>
+            <param name="operationId">操作ID</param>
+            <param name="path">API路径</param>
+            <param name="httpMethod">HTTP方法</param>
+            <param name="summary">摘要</param>
+            <param name="description">描述</param>
+            <param name="operation">操作定义</param>
+            <param name="baseUrl">API基础URL</param>
+        </member>
+        <member name="M:MCPP.Net.Core.CecilAssemblyBuilder.GenerateSchemaDescription(Newtonsoft.Json.Linq.JObject,System.Text.StringBuilder,System.Int32)">
+            <summary>
+            生成Schema的描述信息
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.CecilAssemblyBuilder.NormalizeMethodName(System.String)">
+            <summary>
+            规范化方法名
+            </summary>
+            <param name="operationId">操作ID</param>
+            <returns>规范化的方法名</returns>
+        </member>
+        <member name="M:MCPP.Net.Core.CecilAssemblyBuilder.NormalizeParameterName(System.String)">
+            <summary>
+            规范化参数名
+            </summary>
+            <param name="paramName">参数名</param>
+            <returns>规范化的参数名</returns>
+        </member>
+        <member name="M:MCPP.Net.Core.CecilAssemblyBuilder.FindParameterIndex(Mono.Collections.Generic.Collection{Mono.Cecil.ParameterDefinition},System.String)">
+            <summary>
+            查找参数在集合中的索引
+            </summary>
+            <param name="parameters">参数集合</param>
+            <param name="name">参数名</param>
+            <returns>参数索引，找不到返回-1</returns>
+        </member>
+        <member name="T:MCPP.Net.Core.McpServerExtensions">
+            <summary>
+            <see cref="T:Microsoft.Extensions.DependencyInjection.IMcpServerBuilder"/> extension methods
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.McpServerExtensions.UseToolsKeeper(Microsoft.Extensions.DependencyInjection.IMcpServerBuilder)">
+            <summary>
+            使用 <see cref="T:MCPP.Net.Core.McpToolsKeeper"/> 管理 Tools，方便后续的增删操作
+            </summary>
+        </member>
+        <member name="T:MCPP.Net.Core.McpServerOptionsPostConfigure">
+            <summary>
+            覆盖 <see cref="T:ModelContextProtocol.Server.McpServerOptions"/> 默认配置，使用 <see cref="T:MCPP.Net.Core.McpToolsKeeper"/> 管理 Tools，方便后续的增删操作
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.McpServerOptionsPostConfigure.#ctor(MCPP.Net.Core.McpToolsKeeper)">
+            <summary>
+            覆盖 <see cref="T:ModelContextProtocol.Server.McpServerOptions"/> 默认配置，使用 <see cref="T:MCPP.Net.Core.McpToolsKeeper"/> 管理 Tools，方便后续的增删操作
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.McpServerOptionsPostConfigure.PostConfigure(System.String,ModelContextProtocol.Server.McpServerOptions)">
+            <inheritdoc />
+        </member>
+        <member name="T:MCPP.Net.Core.McpToolsKeeper">
+            <summary>
+            Tool 管理员，可以在运行时添加和删除 Tools
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.McpToolsKeeper.#ctor(Microsoft.Extensions.Logging.ILogger{MCPP.Net.Core.McpToolsKeeper})">
+            <summary>
+            Tool 管理员，可以在运行时添加和删除 Tools
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.McpToolsKeeper.SetTools(ModelContextProtocol.Protocol.Types.ToolsCapability)">
+            <summary>
+            使用原始配置初始化<see cref="T:MCPP.Net.Core.McpToolsKeeper"/>
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.McpToolsKeeper.Add(System.String,System.Collections.Generic.IEnumerable{ModelContextProtocol.Server.McpServerTool})">
+            <summary>
+            添加一个新的 Tool 集合
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.McpToolsKeeper.Remove(System.String)">
+            <summary>
+            移除一个 Tool 集合
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.McpToolsKeeper.ListToolsHandler(ModelContextProtocol.Server.RequestContext{ModelContextProtocol.Protocol.Types.ListToolsRequestParams},System.Threading.CancellationToken)">
+            <summary>
+            获取所有 Tool 集合
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.McpToolsKeeper.CallToolHandler(ModelContextProtocol.Server.RequestContext{ModelContextProtocol.Protocol.Types.CallToolRequestParams},System.Threading.CancellationToken)">
+            <summary>
+            调用指定的 Tool
+            </summary>
+        </member>
         <member name="M:MCPP.Net.McpEndpointRouteBuilderExtensions.MapMcp(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder,System.Func{Microsoft.AspNetCore.Http.HttpContext,ModelContextProtocol.Server.IMcpServer,System.Threading.CancellationToken,System.Threading.Tasks.Task})">
             <summary>
             Sets up endpoints for handling MCP HTTP Streaming transport.
@@ -185,55 +284,6 @@
             <param name="swaggerUrlOrPath">Swagger URL或本地文件路径</param>
             <returns>Swagger JSON内容</returns>
         </member>
-        <member name="M:MCPP.Net.Services.SwaggerImportService.GenerateDynamicToolType(Newtonsoft.Json.Linq.JObject,MCPP.Net.Models.SwaggerImportRequest,System.String)">
-            <summary>
-            生成动态工具类型
-            </summary>
-            <param name="swaggerDoc">Swagger文档对象</param>
-            <param name="request">导入请求</param>
-            <param name="baseUrl">API基础URL</param>
-            <returns>生成的动态类型</returns>
-        </member>
-        <member name="M:MCPP.Net.Services.SwaggerImportService.CreateDynamicMethod(Mono.Cecil.ModuleDefinition,Mono.Cecil.TypeDefinition,System.String,System.String,System.String,System.String,System.String,Newtonsoft.Json.Linq.JObject,System.String)">
-            <summary>
-            创建动态方法
-            </summary>
-            <param name="moduleDefinition">模块定义</param>
-            <param name="typeDefinition">类型定义</param>
-            <param name="operationId">操作ID</param>
-            <param name="path">API路径</param>
-            <param name="httpMethod">HTTP方法</param>
-            <param name="summary">摘要</param>
-            <param name="description">描述</param>
-            <param name="operation">操作定义</param>
-            <param name="baseUrl">API基础URL</param>
-        </member>
-        <member name="M:MCPP.Net.Services.SwaggerImportService.GenerateSchemaDescription(Newtonsoft.Json.Linq.JObject,System.Text.StringBuilder,System.Int32)">
-            <summary>
-            生成Schema的描述信息
-            </summary>
-        </member>
-        <member name="M:MCPP.Net.Services.SwaggerImportService.NormalizeMethodName(System.String)">
-            <summary>
-            规范化方法名
-            </summary>
-            <param name="operationId">操作ID</param>
-            <returns>规范化的方法名</returns>
-        </member>
-        <member name="M:MCPP.Net.Services.SwaggerImportService.NormalizeParameterName(System.String)">
-            <summary>
-            规范化参数名
-            </summary>
-            <param name="paramName">参数名</param>
-            <returns>规范化的参数名</returns>
-        </member>
-        <member name="M:MCPP.Net.Services.SwaggerImportService.RegisterToolMethods(System.Type)">
-            <summary>
-            注册工具方法到MCP服务
-            </summary>
-            <param name="toolType">工具类型</param>
-            <returns>已注册的方法名列表</returns>
-        </member>
         <member name="M:MCPP.Net.Services.SwaggerImportService.GetImportedTools">
             <summary>
             获取所有已导入的工具
@@ -254,14 +304,6 @@
             <param name="className">类名</param>
             <returns>是否删除成功</returns>
         </member>
-        <member name="M:MCPP.Net.Services.SwaggerImportService.FindParameterIndex(Mono.Collections.Generic.Collection{Mono.Cecil.ParameterDefinition},System.String)">
-            <summary>
-            查找参数在集合中的索引
-            </summary>
-            <param name="parameters">参数集合</param>
-            <param name="name">参数名</param>
-            <returns>参数索引，找不到返回-1</returns>
-        </member>
         <member name="M:MCPP.Net.Services.SwaggerImportService.CleanupResources">
             <summary>
             清理资源
@@ -279,6 +321,40 @@
             <param name="builder">MCP服务器构建器</param>
             <param name="dynamicToolTypes">动态生成的工具类型列表</param>
             <returns>MCP服务器构建器</returns>
+        </member>
+        <member name="T:MCPP.Net.UnsafeImports.UnsafeAIFunctionMcpServerTool">
+            <summary>
+            https://github.com/modelcontextprotocol/csharp-sdk/blob/4c537ef86bd8bb10980962a8f0bac001453c5cd9/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.UnsafeImports.UnsafeAIFunctionMcpServerTool.Create(System.Reflection.MethodInfo,System.Text.Json.JsonSerializerOptions)">
+            <summary>
+            
+            </summary>
+            <remarks>
+            Microsoft.Extensions.AI 内部会使用 JsonSerializerOptions，
+            </remarks>
+        </member>
+        <member name="M:MCPP.Net.UnsafeImports.UnsafeAIFunctionMcpServerTool.Create(System.Reflection.MethodInfo,System.Object,ModelContextProtocol.Server.McpServerToolCreateOptions,System.Text.Json.JsonSerializerOptions)">
+            <summary>
+            
+            </summary>
+            <param name="method"></param>
+            <param name="target"></param>
+            <param name="options"></param>
+            <param name="serializerOptions"></param>
+            <returns></returns>
+        </member>
+        <member name="T:MCPP.Net.UnsafeImports.UnsafeAIJsonUtilities">
+            <summary>
+            https://github.com/dotnet/extensions/blob/f1f17e642a685df7e87b805be1efe4729ff725e4/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs#L43-L73
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.UnsafeImports.UnsafeAIJsonUtilities.CreateDefaultOptions">
+            <summary>
+            调用私有方法 Microsoft.Extensions.AI.AIJsonUtilities.CreateDefaultOptions
+            </summary>
+            <returns></returns>
         </member>
         <member name="T:ModelContextProtocol.Server.IMcpServerMethodRegistry">
             <summary>

--- a/src/MCPP.Net/MCPP.Net.xml
+++ b/src/MCPP.Net/MCPP.Net.xml
@@ -30,6 +30,11 @@
             <param name="className">类名</param>
             <returns>操作结果</returns>
         </member>
+        <member name="T:MCPP.Net.Core.CecilAssemblyBuilder">
+            <summary>
+            使用 Mono.Cecil 动态生成程序集
+            </summary>
+        </member>
         <member name="M:MCPP.Net.Core.CecilAssemblyBuilder.CreateDynamicMethod(Mono.Cecil.ModuleDefinition,Mono.Cecil.TypeDefinition,System.String,System.String,System.String,System.String,System.String,Newtonsoft.Json.Linq.JObject,System.String)">
             <summary>
             创建动态方法
@@ -70,6 +75,35 @@
             <param name="parameters">参数集合</param>
             <param name="name">参数名</param>
             <returns>参数索引，找不到返回-1</returns>
+        </member>
+        <member name="T:MCPP.Net.Core.IAssemblyBuilder">
+            <summary>
+            程序集生成器标准接口
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.IAssemblyBuilder.Build(Newtonsoft.Json.Linq.JObject,MCPP.Net.Models.SwaggerImportRequest,System.String)">
+            <summary>
+            根据Swagger文档和请求信息动态生成程序集
+            </summary>
+            <returns>程序集文件路径</returns>
+        </member>
+        <member name="T:MCPP.Net.Core.IToolAssemblyLoader">
+            <summary>
+            管控程序集的加载和卸载，避免因外部引用导致无法卸载程序集
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.IToolAssemblyLoader.Load(System.String)">
+            <summary>
+            加载程序集
+            </summary>
+            <remarks>
+            返回值不要包含 <see cref="T:System.Reflection.Assembly"/>, <see cref="T:System.Type"/>, <see cref="T:System.Runtime.Loader.AssemblyLoadContext"/> 等反射相关类型以及动态程序集中的类型实例，否则在卸载程序集时，可能因外部依赖导致无法卸载程序集
+            </remarks>
+        </member>
+        <member name="M:MCPP.Net.Core.IToolAssemblyLoader.Unload(System.String)">
+            <summary>
+            卸载程序集
+            </summary>
         </member>
         <member name="T:MCPP.Net.Core.McpServerExtensions">
             <summary>
@@ -127,6 +161,60 @@
         <member name="M:MCPP.Net.Core.McpToolsKeeper.CallToolHandler(ModelContextProtocol.Server.RequestContext{ModelContextProtocol.Protocol.Types.CallToolRequestParams},System.Threading.CancellationToken)">
             <summary>
             调用指定的 Tool
+            </summary>
+        </member>
+        <member name="T:MCPP.Net.Core.PluginAssembly">
+            <summary>
+            程序集元数据信息，方便统一管理释放
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.PluginAssembly.#ctor(System.Reflection.Assembly,System.Runtime.Loader.AssemblyLoadContext)">
+            <summary>
+            程序集元数据信息，方便统一管理释放
+            </summary>
+        </member>
+        <member name="P:MCPP.Net.Core.PluginAssembly.SerializerOptions">
+            <summary>
+            绑定到程序集的 <see cref="T:System.Text.Json.JsonSerializerOptions"/>
+            </summary>
+            <remarks>
+            Microsoft.Extensions.Ai 内部通过 ConditionalWeakTable 缓存了 Tool 对应的 MethodInfo 信息，如果不释放将无法卸载程序集。
+            ConditionalWeakTable 的 Key 为 <see cref="T:System.Text.Json.JsonSerializerOptions"/> 对象，所以可以将整个程序集的所有 Tools 对应到一个 <see cref="T:System.Text.Json.JsonSerializerOptions"/> 上，在卸载程序集前删除对象引用即可<br/>
+            https://github.com/dotnet/extensions/blob/f1f17e642a685df7e87b805be1efe4729ff725e4/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs#L219-L247
+            </remarks>
+        </member>
+        <member name="P:MCPP.Net.Core.PluginAssembly.Assembly">
+            <summary>
+            动态生成的程序集
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.PluginAssembly.Dispose">
+            <inheritdoc/>
+        </member>
+        <member name="T:MCPP.Net.Core.ToolAssemblyLoader">
+            <summary>
+            <see cref="T:MCPP.Net.Core.IToolAssemblyLoader"/> 的默认实现
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.ToolAssemblyLoader.#ctor(MCPP.Net.Core.McpToolsKeeper,Microsoft.Extensions.Logging.ILogger{MCPP.Net.Core.ToolAssemblyLoader})">
+            <summary>
+            <see cref="T:MCPP.Net.Core.IToolAssemblyLoader"/> 的默认实现
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.ToolAssemblyLoader.Load(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:MCPP.Net.Core.ToolAssemblyLoader.Unload(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="T:MCPP.Net.Core.ToolLoadedDetail">
+            <summary>
+            <see cref="M:MCPP.Net.Core.IToolAssemblyLoader.Load(System.String)"/> 的返回值，包含了加载的具体信息
+            </summary>
+        </member>
+        <member name="M:MCPP.Net.Core.ToolLoadedDetail.#ctor(System.Collections.Generic.List{System.String},System.Collections.Generic.List{MCPP.Net.Models.ImportedTool})">
+            <summary>
+            <see cref="M:MCPP.Net.Core.IToolAssemblyLoader.Load(System.String)"/> 的返回值，包含了加载的具体信息
             </summary>
         </member>
         <member name="M:MCPP.Net.McpEndpointRouteBuilderExtensions.MapMcp(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder,System.Func{Microsoft.AspNetCore.Http.HttpContext,ModelContextProtocol.Server.IMcpServer,System.Threading.CancellationToken,System.Threading.Tasks.Task})">

--- a/src/MCPP.Net/Program.cs
+++ b/src/MCPP.Net/Program.cs
@@ -1,8 +1,7 @@
 using MCPP.Net;
+using MCPP.Net.Core;
 using MCPP.Net.Services;
 using ModelContextProtocol.Server;
-using Swashbuckle.AspNetCore.SwaggerGen;
-using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,12 +19,16 @@ builder.Services.AddSingleton<IMcpServerMethodRegistry, McpServerMethodRegistry>
 builder.Services.AddHttpClient();
 builder.Services.AddSingleton<ImportedToolsService>();
 builder.Services.AddSingleton<SwaggerImportService>();
+builder.Services.AddSingleton<IToolAssemblyLoader, ToolAssemblyLoader>();
+builder.Services.AddSingleton<IAssemblyBuilder, CecilAssemblyBuilder>();
 
 // 构建MCP服务
 var mcpBuilder = builder.Services.AddMcpServer();
 
 // 注册程序集中的工具 - 必须在Build()之前完成
 mcpBuilder.WithToolsFromAssembly();
+
+mcpBuilder.UseToolsKeeper();
 
 // 构建应用
 var app = builder.Build();

--- a/src/MCPP.Net/Services/SwaggerImportService.cs
+++ b/src/MCPP.Net/Services/SwaggerImportService.cs
@@ -1,19 +1,8 @@
+using MCPP.Net.Core;
 using MCPP.Net.Models;
-using ModelContextProtocol.Server;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using Mono.Cecil.Rocks;
-using Mono.Collections.Generic;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System.ComponentModel;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
-using System.Text;
-using System.Text.RegularExpressions;
 
 namespace MCPP.Net.Services
 {
@@ -23,25 +12,28 @@ namespace MCPP.Net.Services
     public class SwaggerImportService
     {
         private readonly ILogger<SwaggerImportService> _logger;
-        private readonly IMcpServerMethodRegistry _methodRegistry;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IWebHostEnvironment _hostEnvironment;
         private readonly ImportedToolsService _importedToolsService;
+        private readonly IAssemblyBuilder _assemblyBuilder;
+        private readonly IToolAssemblyLoader _toolAssemblyLoader;
         private readonly string _storageDirectory;
         private readonly string _assemblyDirectory;
 
         public SwaggerImportService(
             ILogger<SwaggerImportService> logger,
-            IMcpServerMethodRegistry methodRegistry,
             IHttpClientFactory httpClientFactory,
             IWebHostEnvironment hostEnvironment,
-            ImportedToolsService importedToolsService)
+            ImportedToolsService importedToolsService,
+            IAssemblyBuilder assemblyBuilder,
+            IToolAssemblyLoader toolAssemblyLoader)
         {
             _logger = logger;
-            _methodRegistry = methodRegistry;
             _httpClientFactory = httpClientFactory;
             _hostEnvironment = hostEnvironment;
             _importedToolsService = importedToolsService;
+            _assemblyBuilder = assemblyBuilder;
+            _toolAssemblyLoader = toolAssemblyLoader;
             _storageDirectory = Path.Combine(_hostEnvironment.ContentRootPath, "ImportedSwaggers");
             _assemblyDirectory = _storageDirectory; // 使用相同目录存储程序集
 
@@ -89,33 +81,25 @@ namespace MCPP.Net.Services
                 }
             }
 
-            // 3. 动态生成API工具类
-            Type toolType = GenerateDynamicToolType(swaggerDoc, request, baseUrl);
+            _toolAssemblyLoader.Unload($"{request.NameSpace}.{request.ClassName}");
 
-            // 4. 注册工具方法到MCP服务
-            List<string> registeredMethods = RegisterToolMethods(toolType);
+            var assemblyPath = _assemblyBuilder.Build(swaggerDoc, request, baseUrl);
 
-            // 5. 记录导入工具信息
-            var importedTool = new ImportedTool
+            var loadedDetail = _toolAssemblyLoader.Load(assemblyPath);
+
+            foreach (var importedTool in loadedDetail.ImportedTools)
             {
-                NameSpace = request.NameSpace,
-                ClassName = request.ClassName,
-                ApiCount = registeredMethods.Count,
-                ImportDate = DateTime.Now,
-                SwaggerSource = request.SwaggerUrl,
-                SourceBaseUrl = request.SourceBaseUrl
-            };
-
-            // 将工具信息保存到ImportedToolsService，确保程序重启后能自动加载
-            _importedToolsService.AddImportedTool(importedTool);
+                // 将工具信息保存到ImportedToolsService，确保程序重启后能自动加载
+                _importedToolsService.AddImportedTool(importedTool);
+            }
 
             // 6. 返回导入结果
             return new SwaggerImportResult
             {
                 Success = true,
-                ApiCount = registeredMethods.Count,
+                ApiCount = loadedDetail.RegisteredMethods.Count,
                 ToolClassName = request.ClassName,
-                ImportedApis = registeredMethods
+                ImportedApis = loadedDetail.RegisteredMethods
             };
         }
 
@@ -145,725 +129,6 @@ namespace MCPP.Net.Services
                 }
                 return await File.ReadAllTextAsync(swaggerUrlOrPath);
             }
-        }
-
-        /// <summary>
-        /// 生成动态工具类型
-        /// </summary>
-        /// <param name="swaggerDoc">Swagger文档对象</param>
-        /// <param name="request">导入请求</param>
-        /// <param name="baseUrl">API基础URL</param>
-        /// <returns>生成的动态类型</returns>
-        private Type GenerateDynamicToolType(JObject swaggerDoc, SwaggerImportRequest request, string baseUrl)
-        {
-            string assemblyName = $"{request.NameSpace}.{request.ClassName}";
-            string fileName = $"{assemblyName}_{DateTime.Now:yyyy_MM_dd_HH_mm_ss}.dll";
-            string assemblyPath = Path.Combine(_assemblyDirectory, fileName);
-
-            // 创建新的程序集定义
-            var assemblyDefinition = AssemblyDefinition.CreateAssembly(
-                new AssemblyNameDefinition(assemblyName, new Version(1, 0, 0, 0)),
-                assemblyName,
-                ModuleKind.Dll);
-
-            // 创建主模块
-            ModuleDefinition moduleDefinition = assemblyDefinition.MainModule;
-
-            // 添加必要的引用
-            moduleDefinition.ImportReference(typeof(object));
-            moduleDefinition.ImportReference(typeof(StringBuilder));
-            moduleDefinition.ImportReference(typeof(McpServerToolTypeAttribute));
-            moduleDefinition.ImportReference(typeof(McpServerToolAttribute));
-            moduleDefinition.ImportReference(typeof(DescriptionAttribute));
-
-            // 创建类型定义
-            TypeDefinition typeDefinition = new TypeDefinition(
-                request.NameSpace,
-                request.ClassName,
-                Mono.Cecil.TypeAttributes.Public | Mono.Cecil.TypeAttributes.Abstract | Mono.Cecil.TypeAttributes.Sealed | Mono.Cecil.TypeAttributes.Class,
-                moduleDefinition.ImportReference(typeof(object)));
-
-            // 添加默认构造函数
-            var defaultCtor = new MethodDefinition(
-                ".ctor",
-                Mono.Cecil.MethodAttributes.Public | Mono.Cecil.MethodAttributes.HideBySig | Mono.Cecil.MethodAttributes.SpecialName | Mono.Cecil.MethodAttributes.RTSpecialName,
-                moduleDefinition.ImportReference(typeof(void)));
-
-            var il = defaultCtor.Body.GetILProcessor();
-            il.Append(il.Create(OpCodes.Ldarg_0));
-            il.Append(il.Create(OpCodes.Call, moduleDefinition.ImportReference(typeof(object).GetConstructor(Type.EmptyTypes))));
-            il.Append(il.Create(OpCodes.Ret));
-
-            typeDefinition.Methods.Add(defaultCtor);
-
-            // 添加McpServerToolType特性
-            var customAttribute = new CustomAttribute(
-                moduleDefinition.ImportReference(typeof(McpServerToolTypeAttribute).GetConstructor(Type.EmptyTypes)));
-            typeDefinition.CustomAttributes.Add(customAttribute);
-
-            // 解析Swagger Paths并创建方法
-            JObject paths = (JObject)swaggerDoc["paths"]!;
-
-            foreach (var pathPair in paths)
-            {
-                string path = pathPair.Key;
-                JObject operations = (JObject)pathPair.Value!;
-
-                foreach (var operationPair in operations)
-                {
-                    string httpMethod = operationPair.Key.ToUpper();
-                    JObject operation = (JObject)operationPair.Value!;
-
-                    // 使用namespace + class + path生成operationId
-                    string operationId = $"{request.NameSpace}_{request.ClassName}_{httpMethod}_{path.Replace("/", "_").Trim('_')}";
-                    string summary = operation["summary"]?.ToString() ?? $"HTTP {httpMethod} {path}";
-                    string description = operation["description"]?.ToString() ?? summary;
-
-                    // 创建方法
-                    CreateDynamicMethod(moduleDefinition, typeDefinition, operationId, path, httpMethod, summary, description, operation, baseUrl);
-                }
-            }
-
-            // 将类型添加到模块
-            moduleDefinition.Types.Add(typeDefinition);
-
-            // 将程序集写入磁盘
-            assemblyDefinition.Write(assemblyPath);
-
-            // 创建自定义上下文加载程序集，避免重复加载同名程序集
-            var loadContextName = Guid.NewGuid().ToString();
-            var loadContext = new AssemblyLoadContext(loadContextName, true);
-
-            // 尝试卸载之前可能存在的同名程序集
-            foreach (var existingContext in AssemblyLoadContext.All)
-            {
-                if (existingContext != AssemblyLoadContext.Default &&
-                    existingContext != loadContext &&
-                    existingContext.Name != loadContextName)
-                {
-                    try
-                    {
-                        existingContext.Unload();
-                        _logger.LogInformation("已卸载旧的程序集加载上下文: {ContextName}", existingContext.Name);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(ex, "卸载旧的程序集加载上下文失败: {ContextName}", existingContext.Name);
-                    }
-                }
-            }
-
-            Assembly assembly;
-            try
-            {
-                assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
-                Type dynamicType = assembly.GetType($"{request.NameSpace}.{request.ClassName}")!;
-
-                _logger.LogInformation("已创建动态工具类型: {TypeName}", dynamicType.FullName);
-                return dynamicType;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "加载动态程序集失败: {Path}", assemblyPath);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// 创建动态方法
-        /// </summary>
-        /// <param name="moduleDefinition">模块定义</param>
-        /// <param name="typeDefinition">类型定义</param>
-        /// <param name="operationId">操作ID</param>
-        /// <param name="path">API路径</param>
-        /// <param name="httpMethod">HTTP方法</param>
-        /// <param name="summary">摘要</param>
-        /// <param name="description">描述</param>
-        /// <param name="operation">操作定义</param>
-        /// <param name="baseUrl">API基础URL</param>
-        private void CreateDynamicMethod(
-            ModuleDefinition moduleDefinition,
-            TypeDefinition typeDefinition,
-            string operationId,
-            string path,
-            string httpMethod,
-            string summary,
-            string description,
-            JObject operation,
-            string baseUrl)
-        {
-            // 规范化方法名
-            string methodName = NormalizeMethodName(operationId);
-
-            // 获取参数列表
-            JArray? parameters = (JArray?)operation["parameters"];
-            JObject? requestBody = (JObject?)operation["requestBody"];
-
-            List<string> parameterNames = new List<string>();
-            List<string> parameterDescriptions = new List<string>();
-            List<string> pathParams = new List<string>();
-            List<string> queryParams = new List<string>();
-
-            // 创建方法定义
-            var methodDefinition = new MethodDefinition(
-                methodName,
-                Mono.Cecil.MethodAttributes.Public | Mono.Cecil.MethodAttributes.Static,
-                moduleDefinition.ImportReference(typeof(string)));
-
-            // 处理Path和Query参数
-            if (parameters != null)
-            {
-                foreach (JObject param in parameters)
-                {
-                    string paramName = param["name"]?.ToString() ?? "";
-                    string paramIn = param["in"]?.ToString() ?? "";
-
-                    if (paramIn == "path" || paramIn == "query")
-                    {
-                        string normalizedName = NormalizeParameterName(paramName);
-                        var parameterDefinition = new ParameterDefinition(
-                            normalizedName,
-                            Mono.Cecil.ParameterAttributes.None,
-                            moduleDefinition.ImportReference(typeof(string)));
-
-                        methodDefinition.Parameters.Add(parameterDefinition);
-
-                        // 为参数添加Description特性
-                        string paramDescription = param["description"]?.ToString() ?? $"参数 {paramName}";
-                        var descriptionAttr = new CustomAttribute(
-                            moduleDefinition.ImportReference(
-                                typeof(DescriptionAttribute).GetConstructor(new[] { typeof(string) })));
-                        descriptionAttr.ConstructorArguments.Add(
-                            new CustomAttributeArgument(moduleDefinition.ImportReference(typeof(string)), paramDescription));
-                        parameterDefinition.CustomAttributes.Add(descriptionAttr);
-
-                        parameterNames.Add(normalizedName);
-                        parameterDescriptions.Add(paramDescription);
-
-                        if (paramIn == "path")
-                        {
-                            pathParams.Add(paramName);
-                        }
-                        else if (paramIn == "query")
-                        {
-                            queryParams.Add(paramName);
-                        }
-                    }
-                }
-            }
-
-            // 处理请求体
-            bool hasRequestBody = false;
-            string requestBodySchema = "{}";
-            string requestBodyDescription = "请求体 (JSON格式)";
-
-            if (requestBody != null)
-            {
-                hasRequestBody = true;
-                var parameterDefinition = new ParameterDefinition(
-                    "requestBody",
-                    Mono.Cecil.ParameterAttributes.None,
-                    moduleDefinition.ImportReference(typeof(string)));
-
-                methodDefinition.Parameters.Add(parameterDefinition);
-
-                // 尝试提取请求体Schema和描述
-                if (requestBody["content"] is JObject content &&
-                    content["application/json"] is JObject jsonContent &&
-                    jsonContent["schema"] is JObject schema)
-                {
-                    requestBodySchema = schema.ToString(Formatting.Indented);
-
-                    // 生成详细的请求体描述
-                    var schemaDescription = new StringBuilder();
-                    schemaDescription.AppendLine("请求体结构:");
-                    GenerateSchemaDescription(schema, schemaDescription, 1);
-                    requestBodyDescription = schemaDescription.ToString();
-                }
-
-                // 为请求体参数添加Description特性
-                var descriptionAttr = new CustomAttribute(
-                    moduleDefinition.ImportReference(
-                        typeof(DescriptionAttribute).GetConstructor(new[] { typeof(string) })));
-                descriptionAttr.ConstructorArguments.Add(
-                    new CustomAttributeArgument(moduleDefinition.ImportReference(typeof(string)), requestBodyDescription));
-                parameterDefinition.CustomAttributes.Add(descriptionAttr);
-
-                parameterNames.Add("requestBody");
-                parameterDescriptions.Add(requestBodyDescription);
-            }
-
-            // 添加McpServerTool特性
-            var mcpServerToolAttr = new CustomAttribute(
-                moduleDefinition.ImportReference(
-                    typeof(McpServerToolAttribute).GetConstructor(Type.EmptyTypes)));
-
-            // 设置Name属性
-            var nameProperty = typeof(McpServerToolAttribute).GetProperty("Name");
-            if (nameProperty != null && nameProperty.GetSetMethod() != null)
-            {
-                mcpServerToolAttr.Properties.Add(
-                    new Mono.Cecil.CustomAttributeNamedArgument(
-                        "Name",
-                        new CustomAttributeArgument(moduleDefinition.ImportReference(typeof(string)), methodName.ToLower())));
-            }
-
-            methodDefinition.CustomAttributes.Add(mcpServerToolAttr);
-
-            // 添加Description特性
-            var methodDescAttr = new CustomAttribute(
-                moduleDefinition.ImportReference(
-                    typeof(DescriptionAttribute).GetConstructor(new[] { typeof(string) })));
-            methodDescAttr.ConstructorArguments.Add(
-                new CustomAttributeArgument(moduleDefinition.ImportReference(typeof(string)), description));
-            methodDefinition.CustomAttributes.Add(methodDescAttr);
-
-            // 生成示例HTTP请求代码
-            string fullPath = path;
-            int placeholderIndex = 0;
-            foreach (var pathParam in pathParams)
-            {
-                // 获取规范化的参数名
-                string normalizedName = NormalizeParameterName(pathParam);
-                // 使用简单的字符串替换，添加占位符
-                fullPath = fullPath.Replace($"{{{pathParam}}}", $"{{{placeholderIndex++}}}");
-            }
-
-            string queryString = "";
-            if (queryParams.Count > 0)
-            {
-                queryString = "?";
-                for (int i = 0; i < queryParams.Count; i++)
-                {
-                    if (i > 0)
-                    {
-                        queryString += "&";
-                    }
-                    string paramName = queryParams[i];
-                    string normalizedName = NormalizeParameterName(paramName);
-                    queryString += $"{paramName}={{{placeholderIndex++}}}";
-                }
-            }
-
-            string fullUrl = baseUrl + fullPath + queryString;
-
-            // 获取ILProcessor
-            ILProcessor ilProcessor = methodDefinition.Body.GetILProcessor();
-
-            // 创建变量
-            var httpClientVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(HttpClient)));
-            var responseVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(HttpResponseMessage)));
-            var contentVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(string)));
-            var formattedUrlVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(string)));
-
-            methodDefinition.Body.Variables.Add(httpClientVar);
-            methodDefinition.Body.Variables.Add(responseVar);
-            methodDefinition.Body.Variables.Add(contentVar);
-            methodDefinition.Body.Variables.Add(formattedUrlVar);
-
-            // 格式化 URL，替换路径参数和查询参数
-            if (pathParams.Count > 0 || queryParams.Count > 0)
-            {
-                // 使用 string.Format 方法格式化 URL
-                ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, fullUrl));
-
-                // 添加路径参数
-                foreach (var pathParam in pathParams)
-                {
-                    string normalizedName = NormalizeParameterName(pathParam);
-                    int paramIndex = FindParameterIndex(methodDefinition.Parameters, normalizedName);
-                    if (paramIndex >= 0)
-                    {
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg, paramIndex));
-                    }
-                    else
-                    {
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, ""));
-                    }
-                }
-
-                // 添加查询参数
-                foreach (var queryParam in queryParams)
-                {
-                    string normalizedName = NormalizeParameterName(queryParam);
-                    int paramIndex = FindParameterIndex(methodDefinition.Parameters, normalizedName);
-                    if (paramIndex >= 0)
-                    {
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg, paramIndex));
-                    }
-                    else
-                    {
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, ""));
-                    }
-                }
-
-                // 调用 string.Format 方法
-                var stringFormatMethod = moduleDefinition.ImportReference(
-                    typeof(string).GetMethod("Format", new Type[] {
-                        typeof(string),
-                        typeof(object),
-                        typeof(object),
-                        typeof(object)
-                    }));
-
-                if (pathParams.Count + queryParams.Count == 1)
-                {
-                    stringFormatMethod = moduleDefinition.ImportReference(
-                        typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object) }));
-                }
-                else if (pathParams.Count + queryParams.Count == 2)
-                {
-                    stringFormatMethod = moduleDefinition.ImportReference(
-                        typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object), typeof(object) }));
-                }
-                else if (pathParams.Count + queryParams.Count == 3)
-                {
-                    stringFormatMethod = moduleDefinition.ImportReference(
-                        typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object), typeof(object), typeof(object) }));
-                }
-                else if (pathParams.Count + queryParams.Count > 3)
-                {
-                    // 对于更多参数，使用 params 版本的 Format 方法
-                    stringFormatMethod = moduleDefinition.ImportReference(
-                        typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object[]) }));
-
-                    // 创建数组
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldc_I4, pathParams.Count + queryParams.Count));
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Newarr, moduleDefinition.ImportReference(typeof(object))));
-
-                    // 填充数组
-                    int index = 0;
-                    foreach (var pathParam in pathParams)
-                    {
-                        string normalizedName = NormalizeParameterName(pathParam);
-                        int paramIndex = FindParameterIndex(methodDefinition.Parameters, normalizedName);
-
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Dup));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldc_I4, index));
-
-                        if (paramIndex >= 0)
-                        {
-                            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg, paramIndex));
-                        }
-                        else
-                        {
-                            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, ""));
-                        }
-
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Stelem_Ref));
-                        index++;
-                    }
-
-                    foreach (var queryParam in queryParams)
-                    {
-                        string normalizedName = NormalizeParameterName(queryParam);
-                        int paramIndex = FindParameterIndex(methodDefinition.Parameters, normalizedName);
-
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Dup));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldc_I4, index));
-
-                        if (paramIndex >= 0)
-                        {
-                            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg, paramIndex));
-                        }
-                        else
-                        {
-                            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, ""));
-                        }
-
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Stelem_Ref));
-                        index++;
-                    }
-                }
-
-                ilProcessor.Append(ilProcessor.Create(OpCodes.Call, stringFormatMethod));
-                ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, formattedUrlVar));
-            }
-            else
-            {
-                // 如果没有参数，直接使用 fullUrl
-                ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, fullUrl));
-                ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, formattedUrlVar));
-            }
-
-            // ----------------- 新增发送 HTTP 请求的 IL代码 -----------------
-            // 创建 HttpClient 实例
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Newobj, moduleDefinition.ImportReference(typeof(HttpClient).GetConstructor(Type.EmptyTypes))));
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, httpClientVar));
-
-            // 根据HTTP方法处理不同类型的请求
-            switch (httpMethod.ToUpper())
-            {
-                case "GET":
-                    // 发送 GET 请求
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
-                    var getAsyncMethod = moduleDefinition.ImportReference(typeof(HttpClient).GetMethod("GetAsync", new Type[] { typeof(string) }));
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, getAsyncMethod));
-                    break;
-
-                case "DELETE":
-                    // 发送 DELETE 请求
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
-                    var deleteAsyncMethod = moduleDefinition.ImportReference(typeof(HttpClient).GetMethod("DeleteAsync", new Type[] { typeof(string) }));
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, deleteAsyncMethod));
-                    break;
-
-                case "POST":
-                case "PUT":
-                case "PATCH":
-                    // 创建 HttpContent 用于请求内容
-                    var requestContentVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(StringContent)));
-                    methodDefinition.Body.Variables.Add(requestContentVar);
-
-                    if (hasRequestBody)
-                    {
-                        // 创建 StringContent 实例
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg, methodDefinition.Parameters.Count - 1)); // 最后一个参数是requestBody
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Call, moduleDefinition.ImportReference(typeof(Encoding).GetProperty("UTF8").GetGetMethod())));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, "application/json"));
-                        var stringContentCtor = moduleDefinition.ImportReference(
-                            typeof(StringContent).GetConstructor(new Type[] { typeof(string), typeof(Encoding), typeof(string) }));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Newobj, stringContentCtor));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, requestContentVar));
-                    }
-                    else
-                    {
-                        // 创建空的 StringContent
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, "{}"));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Call, moduleDefinition.ImportReference(typeof(Encoding).GetProperty("UTF8").GetGetMethod())));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldstr, "application/json"));
-                        var stringContentCtor = moduleDefinition.ImportReference(
-                            typeof(StringContent).GetConstructor(new Type[] { typeof(string), typeof(Encoding), typeof(string) }));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Newobj, stringContentCtor));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, requestContentVar));
-                    }
-
-                    // 根据不同的HTTP方法选择相应的请求方式
-                    if (httpMethod.ToUpper() == "POST")
-                    {
-                        // 发送 POST 请求
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, requestContentVar));
-                        var postAsyncMethod = moduleDefinition.ImportReference(
-                            typeof(HttpClient).GetMethod("PostAsync", new Type[] { typeof(string), typeof(HttpContent) }));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, postAsyncMethod));
-                    }
-                    else if (httpMethod.ToUpper() == "PUT")
-                    {
-                        // 发送 PUT 请求
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, requestContentVar));
-                        var putAsyncMethod = moduleDefinition.ImportReference(
-                            typeof(HttpClient).GetMethod("PutAsync", new Type[] { typeof(string), typeof(HttpContent) }));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, putAsyncMethod));
-                    }
-                    else // PATCH 和其他方法
-                    {
-                        // 对于 PATCH 方法，使用 SendAsync 方法
-                        // 先创建一个临时变量存储HttpRequestMessage
-                        var requestMessageVar = new VariableDefinition(moduleDefinition.ImportReference(typeof(HttpRequestMessage)));
-                        methodDefinition.Body.Variables.Add(requestMessageVar);
-
-                        // 创建HttpMethod.Patch
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Call, moduleDefinition.ImportReference(
-                            typeof(HttpMethod).GetProperty("Patch").GetGetMethod())));
-
-                        // 加载URL
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
-
-                        // 创建 HttpRequestMessage
-                        var httpRequestMessageCtor = moduleDefinition.ImportReference(
-                            typeof(HttpRequestMessage).GetConstructor(new Type[] { typeof(HttpMethod), typeof(string) }));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Newobj, httpRequestMessageCtor));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, requestMessageVar));
-
-                        // 设置请求内容
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, requestMessageVar));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, requestContentVar));
-
-                        var contentSetter = moduleDefinition.ImportReference(
-                            typeof(HttpRequestMessage).GetProperty("Content").GetSetMethod());
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, contentSetter));
-
-                        // 发送请求
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, requestMessageVar));
-
-                        var sendAsyncMethod = moduleDefinition.ImportReference(
-                            typeof(HttpClient).GetMethod("SendAsync", new Type[] { typeof(HttpRequestMessage) }));
-                        ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, sendAsyncMethod));
-                    }
-                    break;
-
-                default:
-                    // 默认使用GET请求
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, httpClientVar));
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, formattedUrlVar));
-                    var defaultGetAsyncMethod = moduleDefinition.ImportReference(typeof(HttpClient).GetMethod("GetAsync", new Type[] { typeof(string) }));
-                    ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, defaultGetAsyncMethod));
-                    break;
-            }
-
-            // 调用 Task<HttpResponseMessage>.Result 获取响应结果
-            var taskResponseResultGetter = moduleDefinition.ImportReference(
-                typeof(System.Threading.Tasks.Task<HttpResponseMessage>).GetProperty("Result").GetGetMethod());
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, taskResponseResultGetter));
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, responseVar));
-
-            // 从响应中获取 HttpContent
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, responseVar));
-            var getContentGetter = moduleDefinition.ImportReference(
-                typeof(HttpResponseMessage).GetProperty("Content").GetGetMethod());
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, getContentGetter));
-
-            // 调用 HttpContent.ReadAsStringAsync 并同步获取响应体字符串
-            var readAsStringAsyncMethod = moduleDefinition.ImportReference(
-                typeof(HttpContent).GetMethod("ReadAsStringAsync", Type.EmptyTypes));
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, readAsStringAsyncMethod));
-            var taskStringResultGetter = moduleDefinition.ImportReference(
-                typeof(System.Threading.Tasks.Task<string>).GetProperty("Result").GetGetMethod());
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Callvirt, taskStringResultGetter));
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Stloc, contentVar));
-            // ----------------- 结束发送 HTTP 请求的 IL代码 -----------------
-
-            // 将响应体字符串加载到栈顶，并返回
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldloc, contentVar));
-            ilProcessor.Append(ilProcessor.Create(OpCodes.Ret));
-
-            // 将方法添加到类型
-            typeDefinition.Methods.Add(methodDefinition);
-        }
-
-        /// <summary>
-        /// 生成Schema的描述信息
-        /// </summary>
-        private void GenerateSchemaDescription(JObject schema, StringBuilder description, int indentLevel)
-        {
-            string indent = new string(' ', indentLevel * 2);
-
-            if (schema["type"]?.ToString() == "object")
-            {
-                if (schema["properties"] is JObject properties)
-                {
-                    foreach (var prop in properties)
-                    {
-                        string propName = prop.Key;
-                        JObject propSchema = (JObject)prop.Value!;
-
-                        // 添加属性名和类型
-                        description.Append($"{indent}- {propName}: ");
-
-                        if (propSchema["type"] != null)
-                        {
-                            description.Append(propSchema["type"]!.ToString());
-                        }
-
-                        // 添加描述
-                        if (propSchema["description"] != null)
-                        {
-                            description.Append($" - {propSchema["description"]}");
-                        }
-
-                        description.AppendLine();
-
-                        // 递归处理嵌套对象
-                        if (propSchema["type"]?.ToString() == "object" && propSchema["properties"] != null)
-                        {
-                            GenerateSchemaDescription(propSchema, description, indentLevel + 1);
-                        }
-                        // 处理数组类型
-                        else if (propSchema["type"]?.ToString() == "array" && propSchema["items"] != null)
-                        {
-                            description.Append($"{indent}  - 数组元素类型: ");
-                            if (propSchema["items"]!["type"] != null)
-                            {
-                                description.AppendLine(propSchema["items"]!["type"]!.ToString());
-                            }
-
-                            if (propSchema["items"]!["type"]?.ToString() == "object" &&
-                                propSchema["items"]!["properties"] != null)
-                            {
-                                GenerateSchemaDescription((JObject)propSchema["items"]!, description, indentLevel + 2);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// 规范化方法名
-        /// </summary>
-        /// <param name="operationId">操作ID</param>
-        /// <returns>规范化的方法名</returns>
-        private string NormalizeMethodName(string operationId)
-        {
-            // 移除非法字符，保留字母、数字和下划线
-            string normalized = Regex.Replace(operationId, @"[^a-zA-Z0-9_]", "");
-
-            // 确保以字母开头
-            if (normalized.Length == 0 || !char.IsLetter(normalized[0]))
-            {
-                normalized = "Api" + normalized;
-            }
-
-            return normalized;
-        }
-
-        /// <summary>
-        /// 规范化参数名
-        /// </summary>
-        /// <param name="paramName">参数名</param>
-        /// <returns>规范化的参数名</returns>
-        private string NormalizeParameterName(string paramName)
-        {
-            // 移除非法字符，保留字母、数字和下划线
-            string normalized = Regex.Replace(paramName, @"[^a-zA-Z0-9_]", "");
-
-            // 确保以字母开头
-            if (normalized.Length == 0 || !char.IsLetter(normalized[0]))
-            {
-                normalized = "param" + normalized;
-            }
-
-            // 转换为小驼峰命名
-            return char.ToLowerInvariant(normalized[0]) + normalized.Substring(1);
-        }
-
-        /// <summary>
-        /// 注册工具方法到MCP服务
-        /// </summary>
-        /// <param name="toolType">工具类型</param>
-        /// <returns>已注册的方法名列表</returns>
-        private List<string> RegisterToolMethods(Type toolType)
-        {
-            List<string> registeredMethods = new List<string>();
-
-            // 获取所有标记了[McpServerTool]特性的静态方法
-            var methods = toolType.GetMethods(BindingFlags.Public | BindingFlags.Static)
-                .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() != null);
-
-            // 不清空现有注册，只添加新方法
-            foreach (var method in methods)
-            {
-                // 注册到MCP服务
-                if (!registeredMethods.Contains(method.Name))
-                {
-                    _methodRegistry.AddMethod(method);
-                    registeredMethods.Add(method.Name);
-                }
-                else 
-                {
-                    _logger.LogInformation($"{method.Name} 重复注册");
-                }
-            }
-
-            _logger.LogInformation("已注册 {Count} 个方法到MCP服务", registeredMethods.Count);
-            return registeredMethods;
         }
 
         /// <summary>
@@ -952,12 +217,11 @@ namespace MCPP.Net.Services
 
             try
             {
-                // 删除程序集文件 - 可能有多个时间戳版本
-                var assemblyFiles = Directory.GetFiles(_assemblyDirectory, $"{key}_*.dll");
-                foreach (var assemblyFile in assemblyFiles)
+                var filePath = Path.Combine(_assemblyDirectory, $"{key}.dll");
+                if (File.Exists(filePath))
                 {
-                    File.Delete(assemblyFile);
-                    _logger.LogInformation("已删除工具程序集文件: {FilePath}", assemblyFile);
+                    File.Delete(filePath);
+                    _logger.LogInformation("已删除工具程序集文件: {FilePath}", filePath);
                 }
 
                 // 从ImportedToolsService中移除工具信息
@@ -971,24 +235,6 @@ namespace MCPP.Net.Services
                 _logger.LogError(ex, "删除工具失败: {Key}, {Message}", key, ex.Message);
                 throw;
             }
-        }
-
-        /// <summary>
-        /// 查找参数在集合中的索引
-        /// </summary>
-        /// <param name="parameters">参数集合</param>
-        /// <param name="name">参数名</param>
-        /// <returns>参数索引，找不到返回-1</returns>
-        private int FindParameterIndex(Collection<ParameterDefinition> parameters, string name)
-        {
-            for (int i = 0; i < parameters.Count; i++)
-            {
-                if (parameters[i].Name == name)
-                {
-                    return i;
-                }
-            }
-            return -1;
         }
 
         /// <summary>

--- a/src/MCPP.Net/UnsafeImports/UnsafeAIFunctionMcpServerTool.cs
+++ b/src/MCPP.Net/UnsafeImports/UnsafeAIFunctionMcpServerTool.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.Extensions.AI;
+using ModelContextProtocol.Server;
+using System.Reflection;
+using System.Text.Json;
+
+namespace MCPP.Net.UnsafeImports
+{
+    /// <summary>
+    /// https://github.com/modelcontextprotocol/csharp-sdk/blob/4c537ef86bd8bb10980962a8f0bac001453c5cd9/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+    /// </summary>
+    public static class UnsafeAIFunctionMcpServerTool
+    {
+        private static Func<AIFunction, McpServerToolCreateOptions?, McpServerTool> _Create;
+        private static Func<MethodInfo, McpServerToolCreateOptions?, AIFunctionFactoryOptions> _CreateAIFunctionFactoryOptions;
+        private static Func<MethodInfo, McpServerToolCreateOptions?, McpServerToolCreateOptions> _DeriveOptions;
+
+        static UnsafeAIFunctionMcpServerTool()
+        {
+            var typeAIFunctionMcpServerTool = typeof(McpServerTool).Assembly.GetType("ModelContextProtocol.Server.AIFunctionMcpServerTool");
+            if (typeAIFunctionMcpServerTool is null) throw new InvalidOperationException("无法找到私有类型 ModelContextProtocol.Server.AIFunctionMcpServerTool，可能在当前版本已被移除");
+
+            var methodCreate = typeAIFunctionMcpServerTool.GetMethod("Create", BindingFlags.Static | BindingFlags.Public, [typeof(AIFunction), typeof(McpServerToolCreateOptions)]);
+            if (methodCreate is null) throw new InvalidOperationException("无法找到 AIFunctionMcpServerTool.Create 方法，当前版本的代码实现或许发生了改变");
+            _Create = methodCreate.CreateDelegate<Func<AIFunction, McpServerToolCreateOptions?, McpServerTool>>();
+
+            var methodCreateAIFunctionFactoryOptions = typeAIFunctionMcpServerTool.GetMethod("CreateAIFunctionFactoryOptions", BindingFlags.Static | BindingFlags.NonPublic);
+            if (methodCreateAIFunctionFactoryOptions is null) throw new InvalidOperationException("无法找到 AIFunctionMcpServerTool.CreateAIFunctionFactoryOptions 方法，当前版本的代码实现或许发生了改变");
+            _CreateAIFunctionFactoryOptions = methodCreateAIFunctionFactoryOptions.CreateDelegate<Func<MethodInfo, McpServerToolCreateOptions?, AIFunctionFactoryOptions>>();
+
+            var methodDeriveOptions = typeAIFunctionMcpServerTool.GetMethod("DeriveOptions", BindingFlags.Static | BindingFlags.NonPublic);
+            if (methodDeriveOptions is null) throw new InvalidOperationException("无法找到 AIFunctionMcpServerTool.DeriveOptions 方法，当前版本的代码实现或许发生了改变");
+            _DeriveOptions = methodDeriveOptions.CreateDelegate<Func<MethodInfo, McpServerToolCreateOptions?, McpServerToolCreateOptions>>();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Microsoft.Extensions.AI 内部会使用 JsonSerializerOptions，
+        /// </remarks>
+        public static McpServerTool Create(MethodInfo method, JsonSerializerOptions serializerOptions)
+        {
+            return Create(method, null, null, serializerOptions);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="target"></param>
+        /// <param name="options"></param>
+        /// <param name="serializerOptions"></param>
+        /// <returns></returns>
+        public static McpServerTool Create(MethodInfo method, object? target, McpServerToolCreateOptions? options, JsonSerializerOptions? serializerOptions)
+        {
+            options = _DeriveOptions(method, options);
+
+            var factoryOptions = _CreateAIFunctionFactoryOptions(method, options);
+            factoryOptions.SerializerOptions = serializerOptions;
+
+            var function = AIFunctionFactory.Create(method, target, factoryOptions);
+
+            return _Create(function, options);
+        }
+
+        // 本来准备使用 UnsafeAccessorAttribute 实现的，但是目前 UnsafeAccessorAttribute 不支持私有类型，等支持后直接改用 UnsafeAccessorAttribute
+
+        //[UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "ModelContextProtocol.Server.AIFunctionMcpServerTool.Create")]
+        //private extern static McpServerTool Create(AIFunction function, McpServerToolCreateOptions? options);
+
+        //[UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "ModelContextProtocol.Server.AIFunctionMcpServerTool.CreateAIFunctionFactoryOptions")]
+        //private extern static AIFunctionFactoryOptions CreateAIFunctionFactoryOptions(MethodInfo method, McpServerToolCreateOptions? options);
+
+        //[UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "ModelContextProtocol.Server.AIFunctionMcpServerTool.DeriveOptions")]
+        //private extern static McpServerToolCreateOptions? DeriveOptions(MethodInfo method, McpServerToolCreateOptions? options);
+    }
+}

--- a/src/MCPP.Net/UnsafeImports/UnsafeAIJsonUtilities.cs
+++ b/src/MCPP.Net/UnsafeImports/UnsafeAIJsonUtilities.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Extensions.AI;
+using System.Reflection;
+using System.Text.Json;
+
+namespace MCPP.Net.UnsafeImports
+{
+    /// <summary>
+    /// https://github.com/dotnet/extensions/blob/f1f17e642a685df7e87b805be1efe4729ff725e4/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs#L43-L73
+    /// </summary>
+    public static class UnsafeAIJsonUtilities
+    {
+        private static Func<JsonSerializerOptions> _createDefaultOptions;
+
+        static UnsafeAIJsonUtilities()
+        {
+            var method = typeof(AIJsonUtilities).GetMethod("CreateDefaultOptions", BindingFlags.Static | BindingFlags.NonPublic);
+            if (method is null) throw new InvalidOperationException("无法找到 AIJsonUtilities.CreateDefaultOptions 方法，当前版本的代码实现或许发生了改变");
+
+            _createDefaultOptions = method.CreateDelegate<Func<JsonSerializerOptions>>();
+        }
+
+        /// <summary>
+        /// 调用私有方法 Microsoft.Extensions.AI.AIJsonUtilities.CreateDefaultOptions
+        /// </summary>
+        /// <returns></returns>
+        public static JsonSerializerOptions CreateDefaultOptions() => _createDefaultOptions();
+
+        // 本来准备使用 UnsafeAccessorAttribute 实现的，但是目前 UnsafeAccessorAttribute 不支持静态类型，等支持后直接改用 UnsafeAccessorAttribute
+        //[UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "Microsoft.Extensions.AI.AIJsonUtilities")]
+        //public extern static JsonSerializerOptions CreateDefaultOptions(AIJsonUtilities target);
+    }
+}


### PR DESCRIPTION
现在程序集卸载不掉的主要原因是`Microsoft.Extensions.AI`内部会将 MCP Server Tool 的`MethodInfo`缓存在内存中，`AssemblyLoadContext`的卸载不是强制卸载，在程序集还有在使用的情况下是卸载不掉的。现在通过一些方式，在执行`AssemblyLoadContext.Unload()`之前会先让缓存失效，具体如下：

缓存使用`ConditionalWeakTable<JsonSerializerOptions, ConcurrentDictionary<DescriptorKey, ReflectionAIFunctionDescriptor>>`存储，`MethodInfo`最终会保存在`ConcurrentDictionary`的 Key 中（也就是在`DescriptorKey`里面），参考 [AIFunctionFactory.cs](https://github.com/dotnet/extensions/blob/f1f17e642a685df7e87b805be1efe4729ff725e4/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs#L219-L247)。现在的设计是，让每个程序集对应一个`JsonSerializerOptions`，这样在删除`JsonSerializerOptions`引用时，相关的`MethodInfo`依赖也会进入 GC.

**为了方便整个流程的实现，代码改动比较多，还改动了一些原始逻辑和注释了一些暂时无效的代码。**

1. 新增`McpToolsKeeper`类型，通过该类型管理所有`McpServerTool`

    之前动态添加和删除`McpServerTool`是通过`McpServerOptions.Capabilities.Tools.ToolCollection`直接操作的，一个`McpServerTool`对应的是一个 Method，管理并不方便，特别是删除的时候需要删除程序集所有的 Tools。`McpToolsKeeper`针对程序集分开管理的，方便程序集级别的批量操作。

2. 将使用`Mono.Cecil`生成程序集的代码从`SwaggerImportService`迁移到单独的`CecilAssemblyBuilder`中，并新增标准接口`IAssemblyBuilder`，方便后续扩展。
3. 生成的程序集名称不再包含时间戳后缀。目前没有发现时间戳后缀的实际用途，现在能正常卸载的情况下不会出现版本冲突，不使用后面在目前的代码上方便操作，所以这里就给改掉了。
4. 将动态程序集的管理全部收口到`ToolAssemblyLoader`，避免误操作导致外部依赖动态程序集致使程序集无法卸载。
5. 注释从`ImportedTools`文件夹加载程序集的逻辑。启动总有错误日志，并且会重复添加记录到`_importedTools`中。